### PR TITLE
[Edit] Adjust hovered Map being before the others

### DIFF
--- a/DungeonDuell/Assets/DungeonDuell/Prefab/CardsPhase/Card/Card.prefab
+++ b/DungeonDuell/Assets/DungeonDuell/Prefab/CardsPhase/Card/Card.prefab
@@ -797,7 +797,7 @@ RectTransform:
   m_GameObject: {fileID: 3448330194302316404}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.1564324, y: 1.2576202, z: 1.1564324}
+  m_LocalScale: {x: 1.1564324, y: 1.2576203, z: 1.1564324}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2087125032292074140}

--- a/DungeonDuell/Assets/DungeonDuell/Script/CardPhase/DisplayCard.cs
+++ b/DungeonDuell/Assets/DungeonDuell/Script/CardPhase/DisplayCard.cs
@@ -2,6 +2,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
+using UnityEngine.UI;
 
 namespace dungeonduell
 {
@@ -30,9 +31,11 @@ namespace dungeonduell
 
         private Vector3 _originalScale;
 
+        private Selectable _selectable;
 
         private void Start()
         {
+            _selectable = GetComponent<Selectable>();
             if (handPanel == null)
             {
                 var cth = GetComponentInParent<CardToHand>();
@@ -46,20 +49,20 @@ namespace dungeonduell
             _originalPosition = transform.localPosition;
             _originalRotation = transform.localRotation;
 
-            var index = transform.GetSiblingIndex();
+
             var parent = transform.parent;
 
             if (parent != null)
             {
-                if (index > 0)
+                if (_selectable.navigation.selectOnLeft != null)
                 {
-                    var leftNeighbor = parent.GetChild(index - 1);
+                    var leftNeighbor = _selectable.navigation.selectOnLeft.transform;
                     _originalLeftPosition = leftNeighbor.localPosition;
                 }
 
-                if (index < parent.childCount - 1)
+                if (_selectable.navigation.selectOnRight != null)
                 {
-                    var rightNeighbor = parent.GetChild(index + 1);
+                    var rightNeighbor = _selectable.navigation.selectOnRight.transform;
                     _originalRightPosition = rightNeighbor.localPosition;
                 }
             }
@@ -109,6 +112,7 @@ namespace dungeonduell
 
         private void ActivateHoverEffect()
         {
+            transform.SetSiblingIndex(transform.parent.childCount);
             if (transform.parent == handPanel)
             {
                 transform.localScale = hoverScale;
@@ -143,11 +147,9 @@ namespace dungeonduell
             var parent = transform.parent;
             if (parent == null) return;
 
-            var currentIndex = transform.GetSiblingIndex();
-
-            if (currentIndex > 0)
+            if (_selectable.navigation.selectOnLeft != null)
             {
-                var leftNeighbor = parent.GetChild(currentIndex - 1);
+                var leftNeighbor = _selectable.navigation.selectOnLeft.transform;
                 if (leftNeighbor.TryGetComponent<DisplayCard>(out _))
                 {
                     if (isHovering)
@@ -157,9 +159,9 @@ namespace dungeonduell
                 }
             }
 
-            if (currentIndex < parent.childCount - 1)
+            if (_selectable.navigation.selectOnRight != null)
             {
-                var rightNeighbor = parent.GetChild(currentIndex + 1);
+                var rightNeighbor = _selectable.navigation.selectOnRight.transform;
                 if (rightNeighbor.TryGetComponent<DisplayCard>(out _))
                 {
                     if (isHovering)


### PR DESCRIPTION
Because Unity has not render for z-postion or layer for element in a canvas (for diffrent canvas it would have but not useful here as it block clicks) it was Necessary a small rework of how the neighbor card are affected. This was needed as the child postion needed to be changed to make this possible and the previous solution to get  neighbor depended on the child index.