### PR TITLE
[Edit] Adjust how played Card are tracked to avoid Bugs

### DIFF
--- a/DungeonDuell/Assets/DungeonDuell/Script/CardPhase/CardToHand.cs
+++ b/DungeonDuell/Assets/DungeonDuell/Script/CardPhase/CardToHand.cs
@@ -142,7 +142,9 @@ namespace dungeonduell
             }
             else
             {
-                handCards.Remove(clickedCard.card);
+                var indexOfItem = handCards.IndexOf(clickedCard.card);
+                if (indexOfItem != -1)
+                    handCards.RemoveAt(indexOfItem);
 
                 if (cardHolder.childCount > 0)
                 {
@@ -246,10 +248,8 @@ namespace dungeonduell
         {
             var selectables = new List<Selectable>();
 
-            foreach (var card in handCards)
+            foreach (DisplayCard displayCard in _displayCards)
             {
-                var displayCard = _displayCards.Find(dc => dc.card == card);
-
                 if (displayCard != null)
                 {
                     var selectable = displayCard.GetComponent<Selectable>();
@@ -289,7 +289,6 @@ namespace dungeonduell
         {
             if (player1Played == isPlayer1)
             {
-                handCards.Remove(card);
                 if (handCards.Count == 0) DdCodeEventHandler.Trigger_PlayedAllCards(isPlayer1);
             }
         }


### PR DESCRIPTION
Während Entwickckung sind mir zwei Bugs aufgefallen , der Branch fix die.
Es waren
- Hast du zwei gleiche Karten Typen (gleiche Ausgänge und Typ) in der Hand kannst machmal eine von den mit Controller nicht mehr ansteuren --- Das System dahinter ist quasi bei ansteuren von Karten davon ausgegangen das es keine dobbelten gibt , was natürlich doch prassiren kann so habe ich das System angepasst.

- Hast du zwei gleiche Karten Typen (gleiche Ausgänge und Typ) in der Hand kann es prassiren das die Runde start obwohl du noch Karten hast. --- Das System entfernte Karten in Hintergrund einmal zu viel , egal wenn all Karten ungleich , Problem wenn nicht, habe entsprechende Anpassungen gemacht.
